### PR TITLE
feat: Add compilation smoke tests for koog-agents

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -136,6 +136,10 @@ jobs:
         if: matrix.os == 'macos-latest' && github.event.pull_request.draft == false && github.repository == 'jetbrains/koog'
         run: ./gradlew linkIosSimulatorArm64 iosSimulatorArm64Test --continue
 
+      - name: jsTest and wasmJsTest with Gradle Wrapper
+        if: matrix.os == 'ubuntu-latest'
+        run: ./gradlew jsTest wasmJsTest --continue
+
       - name: Archive coverage data
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v6

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -148,6 +148,24 @@ kotlin {
         wasmJsMain.dependencies {
             api(libs.ktor.client.js)
         }
+
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+            }
+        }
+
+        jsTest {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
+        }
     }
 }
 

--- a/koog-agents/src/commonTest/kotlin/KoogCompilationTest.kt
+++ b/koog-agents/src/commonTest/kotlin/KoogCompilationTest.kt
@@ -1,0 +1,16 @@
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import kotlin.test.Test
+
+class KoogCompilationTest {
+
+    @Test
+    fun test() {
+        listOf(
+            AIAgent::class,
+            PromptExecutor::class,
+            LLModel::class,
+        )
+    }
+}


### PR DESCRIPTION
Add a basic compilation smoke test for the `koog-agents` module to ensure that the key classes (`AIAgent`, `PromptExecutor`, `LLModel`) are correctly included in the compilation classpath.

This also involves adding the necessary Kotlin test dependencies for `commonTest`, `jvmTest`, and `jsTest` to the Gradle build file.

<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
